### PR TITLE
Fixed initial orientation of point cloud map.

### DIFF
--- a/config/params_Asta_Rig.yaml
+++ b/config/params_Asta_Rig.yaml
@@ -6,8 +6,8 @@
     pointCloudTopic: "/velodyne_points"          # Point cloud data
     imuTopic: "/ins/imu"         # IMU data
 
-    odomTopic: "/ins/odometry_vehicle"                   # IMU pre-preintegration odometry, same frequency as IMU
-    gpsTopic: "/ins/odometry_vehicle"                    # GPS odometry topic from navsat, see module_navsat.launch file 
+    odomTopic: "/ins/odometry_lidar"                   # IMU pre-preintegration odometry, same frequency as IMU
+    gpsTopic: "/ins/odometry_lidar"                    # GPS odometry topic from navsat, see module_navsat.launch file 
 
     useDownSampling: true                      # Set to false to disable all downsampling of scans
 

--- a/src/mapOptmization.cpp
+++ b/src/mapOptmization.cpp
@@ -535,16 +535,6 @@ public:
     }
 
 
-
-
-
-
-
-
-
-
-
-
     void loopClosureThread()
     {
         if (loopClosureEnableFlag == false)
@@ -820,16 +810,6 @@ public:
         pubLoopConstraintEdge->publish(markerArray);
     }
 
-
-
-
-
-
-
-    
-
-
-
     void updateInitialGuess()
     {
         // save current transformation before any processing
@@ -839,9 +819,21 @@ public:
         // initialization
         if (cloudKeyPoses3D->points.empty())
         {
-            transformTobeMapped[0] = cloudInfo.imu_roll_init;
-            transformTobeMapped[1] = cloudInfo.imu_pitch_init;
-            transformTobeMapped[2] = cloudInfo.imu_yaw_init;
+            // We trust the OxTs to be accurate so move initial guess to OxTs position
+            if (cloudInfo.odom_available == true)
+            {   
+                transformTobeMapped[0] = cloudInfo.initial_guess_roll;
+                transformTobeMapped[1] = cloudInfo.initial_guess_pitch;
+                transformTobeMapped[2] = cloudInfo.initial_guess_yaw;
+                transformTobeMapped[3] = cloudInfo.initial_guess_x;
+                transformTobeMapped[4] = cloudInfo.initial_guess_y;
+                transformTobeMapped[5] = cloudInfo.initial_guess_z;
+            } else 
+            {
+                transformTobeMapped[0] = cloudInfo.imu_roll_init;
+                transformTobeMapped[1] = cloudInfo.imu_pitch_init;
+                transformTobeMapped[2] = cloudInfo.imu_yaw_init;
+            }
 
             if (!useImuHeadingInitialization)
                 transformTobeMapped[2] = 0;


### PR DESCRIPTION
After the replacement of the imuPreIntegration node with oxford odometry the reference origin of the map was different.  Previously the map origin was at the location of the first received pointcloud and now at the init position of the oxts unit.

This caused the first pointclouds to always be positioned in the origin and with incorrect rotation:

![Incorrect](https://github.com/TixiaoShan/LIO-SAM/assets/23191287/78420342-a305-4930-a71a-a707e21000f8)

This fix inits the position of the first pointcloud to the same position as the oxford unit
![Correct](https://github.com/TixiaoShan/LIO-SAM/assets/23191287/341d8130-ba98-4c3d-b9dc-348ff1b3f0f7)

